### PR TITLE
Avoid "asset management" in blog post title, kind of

### DIFF
--- a/_posts/2018-11-20-using-elm-and-parceljs-forseamless-asset-management.md
+++ b/_posts/2018-11-20-using-elm-and-parceljs-forseamless-asset-management.md
@@ -1,6 +1,6 @@
 ---
 layout:     post
-title:      Using Elm and Parcel for zero configuration web asset bundling
+title:      Using Elm and Parcel for zero configuration web asset management
 date:       2018-11-20
 summary:    Tired of configuring webpack? A simple getting started guide to drop your 400 lines of javascript
 categories: elm


### PR DESCRIPTION
It's not very descriptive and not all of our audience is into web development.
Also it might have alienated decision makers.