### PR TITLE
Fix sprint number by removing sprint numbers

### DIFF
--- a/_posts/2019-05-14-sprint-3-report.md
+++ b/_posts/2019-05-14-sprint-3-report.md
@@ -8,7 +8,7 @@ author:     domenkozar
 categories: sprints, hercules-ci
 ---
 
-# What's new in sprint #3?
+What's new?
 
 ## Precise derivations improvements
 
@@ -35,7 +35,7 @@ We've addressed some of the styling issues visible on smaller screens.
 [nix-gitignore]: https://github.com/siers/nix-gitignore
 [gitignore]: https://github.com/hercules-ci/gitignore
 
-# Focus for sprint #3
+# Focus for the next sprint
 
 ## Cachix and thus Darwin support
 


### PR DESCRIPTION
Also change the first header because it goes right after the title, which is also a header.

https://deploy-preview-45--blog-hercules-ci.netlify.com/sprints,/hercules-ci/2019/05/14/sprint-3-report/